### PR TITLE
Rolled back the single-quotes around ADAPTER_SEQ in STAR_PARAMS_CLIP.

### DIFF
--- a/RNAseqWorkflow_1.3.0.iml
+++ b/RNAseqWorkflow_1.3.0.iml
@@ -5,7 +5,9 @@
       <configuration sdkName="Python 2.7 (AlignmentAndQCWorkflows)" />
     </facet>
   </component>
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
+  <component name="NewModuleRootManager">
+    <output url="file://$MODULE_DIR$/../../out/production/RNAseqWorkflow" />
+    <output-test url="file://$MODULE_DIR$/../../out/test/RNAseqWorkflow" />
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
@@ -16,5 +18,7 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Python 2.7 (AlignmentAndQCWorkflows) interpreter library" level="application" />
+    <orderEntry type="library" name="R User Library" level="project" />
+    <orderEntry type="library" name="R Skeletons" level="application" />
   </component>
 </module>

--- a/resources/configurationFiles/analysisRNAseq.xml
+++ b/resources/configurationFiles/analysisRNAseq.xml
@@ -134,7 +134,7 @@
         <cvalue name='ADAPTER_SEQ_NEXTERA'      value="CTGTCTCTTATACACATCT" type='string' description="Nextera, Nextera XT, Nextera Enrichment, Nextera Rapid Capture Enrichment, TruSight Enrichment, TruSight Rapid Capture Enrichment, TruSight HLA"/>
         <cvalue name='ADAPTER_SEQ_NEXTERA_MP'   value="CTGTCTCTTATACACATCT AGATGTGTATAAGAGACAG" type='string' description="Nextera Mate Pair"/>
         <cvalue name='ADAPTER_SEQ' value='${ADAPTER_SEQ_TRUSEQ_LT_HT}' type='string'/>
-        <cvalue name='STAR_PARAMS_CLIP' value="--clip3pAdapterSeq '${ADAPTER_SEQ}'" type='string'/>
+        <cvalue name='STAR_PARAMS_CLIP' value="--clip3pAdapterSeq ${ADAPTER_SEQ}" type='string'/>
         <cvalue name='GENOME_STAR_INDEX' value='${GENOME_STAR_INDEX_200}' type='string'/>
         <cvalue name='STAR_PARAMS_BASIC'
                 value='--sjdbOverhang 200 --runThreadN ${CORES} --outFileNamePrefix ${STAR_PREFIX}. --genomeDir ${GENOME_STAR_INDEX} --runRNGseed 1234 --outTmpDir ${SCRATCH}/${SAMPLE}_${pid}_STAR'


### PR DESCRIPTION
Without these quotes STAR can identify all adapters as adapters. E.g.

```
--clip3pAdapterSeq AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGTAGATCTCGGTGGTCGCCGTATCATT
```
results in a .Log.out file stating

```
clip3pAdapterSeq                  AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC   AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGTAGATCTCGGTGGTCGCCGTATCATT
```

Note that both values are assigned to the correct parameter.

Compare now to

```
--clip3pAdapterSeq 'AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGTAGATCTCGGTGGTCGCCGTATCATT'
```

which results in a .Log.out file stating

```
clip3pAdapterSeq                  "AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGTAGATCTCGGTGGTCGCCGTATCATT"
```

Note that the single-quotes are substituted by double quotes. STAR seems to group the two together. It is not clear what STAR does with an adapter sequence containing a space, but certainly not an error message or even a warning.

Because the STAR manual never uses quotes also for space-delimited argument lists to parameters, the first and unquoted version is conformant to the documentation.