### PR TITLE
Bugfix: broken automatic fastq search (serious)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,10 @@ G Set your star index (GENOME_STAR_INDEX) and gene models (GENE_MODELS) paramete
 
 ## Change Log
 
-* 2.0.0 [March 2020]
+* 2.0.1 [July 2020]
+  - Bugfix: Variable `SEQUENCING_PROTOCOL` was statically overwritten to be "paired". In a mode where the plugin retrieves the files from the filesystem (i.e. without `FASTQ_LIST`), the workflow therefore searched for FASTQs below the "paired" rather than "single" directory.
+
+* 2.0.0 [13th March 2020]
   - Update Arriba to version 1.2.0
   - Update STAR to 2.5.3a
   - Update Samtools to 1.6

--- a/resources/configurationFiles/analysisRNAseq.xml
+++ b/resources/configurationFiles/analysisRNAseq.xml
@@ -19,8 +19,6 @@
         <cvalue name="useCentralAnalysisArchive" value="true"/>
         <cvalue name="enableJobProfiling" value="false"/>
         <cvalue name='QUAL' value='phred' description="Default quality is phred, can be illumina."/>
-        <!-- ## Imported from commonCOWorkflowsSettings -->
-        <cvalue name='SEQUENCER_PROTOCOL' value='paired' type="string"  description="only paired read sequencing is currently supported"/>
 
         <!-- ## -->
         <!-- ## SOME RUNTIME_CONFIG PARMS -->


### PR DESCRIPTION
The variable "SEQUENCING_PROTOCOL", usually automatically determined by the COWorkflowBasePlugin to be "single" or "paired", is statically overwritten to be "paired" in the plugin configuration. 

Impact: The variable value is used to identify FASTQs in the filesystem structure (if the plugin is used in this mode). If it is set to "paired" but single-end data should be processed, the FASTQs are expected in the  ".../paired/..." directory. If  they are not found there, they won't be discovered. Even worse, if there are also paired-end FASTQs then the **wrong** FASTQs may be used, which is why the bug is classified "serious".

This is a bugfix and should be released patch-level release (2.0.1, maybe also 1.3.1).