### PR TITLE
Increased default subread version to 1.6.5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The following is a list of citations for software used by the RNAseq workflow. N
 * [star 2.5.3a](https://www.ncbi.nlm.nih.gov/pubmed/23104886)
 * [samtools 1.6](https://www.ncbi.nlm.nih.gov/pubmed/19505943)
 * [arriba 1.2.0](https://github.com/suhrig/arriba/)
-* [subread 1.5.1](http://subread.sourceforge.net/) providing [featurecounts 1.5.1](https://www.ncbi.nlm.nih.gov/pubmed/24227677)
+* [subread 1.6.5](http://subread.sourceforge.net/) providing [featurecounts](https://www.ncbi.nlm.nih.gov/pubmed/24227677)
 * [rnaseqc 1.1.8](https://www.ncbi.nlm.nih.gov/pubmed/22539670)
 * [sambamba 0.6.5](https://www.ncbi.nlm.nih.gov/pubmed/25697820)
 * [qualimap 2.2.1](http://qualimap.bioinfo.cipf.es/)
@@ -189,6 +189,9 @@ G Set your star index (GENOME_STAR_INDEX) and gene models (GENE_MODELS) paramete
 
 ## Change Log
 
+* 3.1.0
+  - patch: Updated default from subread 1.5.1 to 1.6.5. The previous version produces occasional segmentation faults (related to extreme optimization option `-O6`) but otherwise produces the same results. Both versions produced exactly the same `featureCounts` in multiple tests.
+
 * 3.0.0 [19th Oct 2021]
   - major: Column rename in feature counts table:
     - "FPKM{,_fw,_rv}" -> "FPKM_no_mt_rrna_trna_chrxy{,_fw,_rv}"
@@ -237,7 +240,7 @@ G Set your star index (GENOME_STAR_INDEX) and gene models (GENE_MODELS) paramete
   - Modified output file check of BAM file
   
 * 1.2.23-1 [26th Jan 2018]
-  - changed default samtools to v1.6 from v1.3.1
+  - Changed default samtools from v1.3.1 to v1.6
 
 * 1.2.23 [25th Jan 2018]
   - Update to Roddy 3.5 that fixes a non-quoting error with the Bash environment and spaces in referenced variables (relevant for adapter variables).

--- a/resources/configurationFiles/analysisRNAseq.xml
+++ b/resources/configurationFiles/analysisRNAseq.xml
@@ -64,7 +64,7 @@
         <!-- ## -->
         <cvalue name='PYTHON_VERSION' value='2.7.9' type='string'/>
         <cvalue name='STAR_VERSION' value='2.5.3a' type='string'/>
-        <cvalue name='SUBREAD_VERSION' value='1.5.1' type='string'/>
+        <cvalue name='SUBREAD_VERSION' value='1.6.5' type='string'/>
         <cvalue name='SAMBAMBA_VERSION' value='0.6.5' type='string'/>
         <cvalue name='SAMTOOLS_VERSION' value='1.9' type='string'/>
         <cvalue name='HTSLIB_VERSION' value='1.9' type='string'/>


### PR DESCRIPTION
* Why not subread 2?
  * I tried subread 2.0.1 (from Conda), but it produced lots of warning of the type "WARNING: feature name on the 504075-th line is longer than 254 bytes. The name is truncated" with our data. Also a test indicates that the results are different (the diff is not trivial; no exact quantification of "different" was done).
  * subread >=2.0.2 requires [additional parameters](http://subread.sourceforge.net/) for paired-end counting. Changing the workflow would preclude the downgrade back to 1.x.
* I compared 1.5.1 vs. 1.6.5 and found no differences in the `featureCounts` results as called in the workflow. I still suggest to increase the minor number, to indicate the minor-number increase in subread.