### PR TITLE
update Arriba to 2.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ The reference data is configurable via the following configuration values.
 | GENOME_STAR_INDEX_100 | Path to STAR index for read length 100 pb | ${indexDirectory}/STAR/STAR_2.5.2b_1KGRef_PhiX_Gencode19_100bp  |
 | GENOME_STAR_INDEX_200 | Path to STAR index for read length 200 pb | ${indexDirectory}/STAR/STAR_2.5.2b_1KGRef_PhiX_Gencode19_200bp |
 | GENOME_KALLISTO_INDEX | |  ${indexDirectory}/kallisto/kallisto-0.43.0_1KGRef_Gencode19_k31/kallisto-0.43.0_1KGRef_Gencode19_k31.noGenes.index |
-| ARRIBA_KNOWN_FUSIONS | GZipped TSV | ${hg19BaseDirectory}/tools_data/arriba/known_fusions_CancerGeneCensus_gencode19_2017-05-11.tsv.gz | 
-| ARRIBA_BLACKLIST | GZipped TSV | ${hg19BaseDirectory}/tools_data/arriba/blacklist_hg19_hs37d5_GRCh37_2018-11-04.tsv.gz |
-| ARRIBA_PROTEIN_DOMAINS | GFF3 | ${hg19BaseDirectory}/tools_data/arriba/protein_domains_hg19_hs37d5_GRCh37_2019-07-05.gff3 |
-| ARRIBA_CYTOBANDS | TSV | ${hg19BaseDirectory}/tools_data/arriba/cytobands_hg19_hs37d5_GRCh37_2018-02-23.tsv |
+| ARRIBA_KNOWN_FUSIONS | GZipped TSV | ${hg19BaseDirectory}/tools_data/arriba/known_fusions_hg19_hs37d5_GRCh37_v2.2.1.tsv.gz | 
+| ARRIBA_BLACKLIST | GZipped TSV | ${hg19BaseDirectory}/tools_data/arriba/blacklist_hg19_hs37d5_GRCh37_v2.2.1.tsv.gz |
+| ARRIBA_PROTEIN_DOMAINS | GFF3 | ${hg19BaseDirectory}/tools_data/arriba/protein_domains_hg19_hs37d5_GRCh37_v2.2.1.gff3 |
+| ARRIBA_CYTOBANDS | TSV | ${hg19BaseDirectory}/tools_data/arriba/cytobands_hg19_hs37d5_GRCh37_v2.2.1.tsv |
 
 The Arriba files are available via the Arriba release tarball available at [GitHub](https://github.com/suhrig/arriba/).
 

--- a/resources/analysisTools/rnaseqworkflow/environments/tbi-cluster-composite-module.sh
+++ b/resources/analysisTools/rnaseqworkflow/environments/tbi-cluster-composite-module.sh
@@ -10,6 +10,5 @@ if [ "$LOAD_MODULE" == true ]; then
     export KALLISTO_BINARY=kallisto
     export QUALIMAP_BINARY=qualimap
     export ARRIBA_BINARY=arriba
-    export ARRIBA_READTHROUGH_BINARY=extract_read-through_fusions
     export ARRIBA_DRAW_FUSIONS=draw_fusions.R
 fi

--- a/resources/analysisTools/rnaseqworkflow/environments/tbi-cluster.sh
+++ b/resources/analysisTools/rnaseqworkflow/environments/tbi-cluster.sh
@@ -32,7 +32,6 @@ export QUALIMAP_BINARY=qualimap
 
 module load "arriba/${ARRIBA_VERSION:?No ARRIBA_VERSION}"
 export ARRIBA_BINARY=arriba
-export ARRIBA_READTHROUGH_BINARY=extract_read-through_fusions
 export ARRIBA_DRAW_FUSIONS=draw_fusions.R
 
 module load "R/${R_VERSION:?No R_VERSION}"

--- a/resources/analysisTools/rnaseqworkflow/rnaseq_processing.sh
+++ b/resources/analysisTools/rnaseqworkflow/rnaseq_processing.sh
@@ -264,7 +264,7 @@ then
 	make_directory "$ARRIBA_DIR"
 	cd "$ARRIBA_DIR"
 
-	arribaCommand="$ARRIBA_BINARY -c '$ALIGNMENT_DIR/$STAR_CHIMERA_MKDUP_BAM' -x '$ALIGNMENT_DIR/$STAR_SORTED_MKDUP_BAM' -a '$GENOME_FA' -k '$ARRIBA_KNOWN_FUSIONS' -g '$GENE_MODELS' -b '$ARRIBA_BLACKLIST' -T -P -o '$ARRIBA_DIR/${SAMPLE}_$pid.fusions.txt' -I -O '$ARRIBA_DIR/${SAMPLE}_$pid.discarded_fusions.txt'"
+	arribaCommand="$ARRIBA_BINARY -c '$ALIGNMENT_DIR/$STAR_CHIMERA_MKDUP_BAM' -x '$ALIGNMENT_DIR/$STAR_SORTED_MKDUP_BAM' -a '$GENOME_FA' -k '$ARRIBA_KNOWN_FUSIONS' -t '$ARRIBA_TAGS' -g '$GENE_MODELS' -b '$ARRIBA_BLACKLIST' -o '$ARRIBA_DIR/${SAMPLE}_$pid.fusions.txt' -O '$ARRIBA_DIR/${SAMPLE}_$pid.discarded_fusions.txt'"
 
 	echo_run "$arribaCommand"
 

--- a/resources/configurationFiles/analysisRNAseq.xml
+++ b/resources/configurationFiles/analysisRNAseq.xml
@@ -71,7 +71,7 @@
         <cvalue name='RNASEQC_VERSION' value='1.1.8' type='string'/>
         <cvalue name='KALLISTO_VERSION' value='0.43.0' type='string'/>
         <cvalue name='QUALIMAP_VERSION' value='2.2.1' type='string'/>
-        <cvalue name='ARRIBA_VERSION' value='1.2.0' type='string'/>
+        <cvalue name='ARRIBA_VERSION' value='2.2.1' type='string'/>
         <cvalue name='R_VERSION' value='3.4.2' type='string'/>
         <cvalue name='STAR_MODULE_NAME' value='STAR' type='string'/>
 
@@ -126,10 +126,11 @@
         <cvalue name='GENOME_STAR_INDEX_100' value='${hg19IndexDirectory}/STAR/STAR_2.5.2b_1KGRef_PhiX_Gencode19_100bp' type='string'/>
         <cvalue name='GENOME_STAR_INDEX_200' value='${hg19IndexDirectory}/STAR/STAR_2.5.2b_1KGRef_PhiX_Gencode19_200bp' type='string'/>
         <cvalue name='GENOME_KALLISTO_INDEX' value='${hg19IndexDirectory}/kallisto/kallisto-0.43.0_1KGRef_Gencode19_k31/kallisto-0.43.0_1KGRef_Gencode19_k31.noGenes.index' type='string'/>
-        <cvalue name='ARRIBA_KNOWN_FUSIONS' value='${hg19BaseDirectory}/tools_data/arriba/known_fusions_CancerGeneCensus_gencode19_2017-05-11.tsv.gz' type='string'/>
-        <cvalue name='ARRIBA_BLACKLIST' value='${hg19BaseDirectory}/tools_data/arriba/blacklist_hg19_hs37d5_GRCh37_2018-11-04.tsv.gz' type='string'/>
-        <cvalue name='ARRIBA_PROTEIN_DOMAINS' value='${hg19BaseDirectory}/tools_data/arriba/protein_domains_hg19_hs37d5_GRCh37_2019-07-05.gff3' type='string'/>
-        <cvalue name='ARRIBA_CYTOBANDS' value='${hg19BaseDirectory}/tools_data/arriba/cytobands_hg19_hs37d5_GRCh37_2018-02-23.tsv' type="string"/>
+        <cvalue name='ARRIBA_KNOWN_FUSIONS' value='${hg19BaseDirectory}/tools_data/arriba/known_fusions_hg19_hs37d5_GRCh37_v${ARRIBA_VERSION}.tsv.gz' type='string'/>
+        <cvalue name='ARRIBA_TAGS' value='${ARRIBA_KNOWN_FUSIONS}' type='string'/>
+        <cvalue name='ARRIBA_BLACKLIST' value='${hg19BaseDirectory}/tools_data/arriba/blacklist_hg19_hs37d5_GRCh37_v${ARRIBA_VERSION}.tsv.gz' type='string'/>
+        <cvalue name='ARRIBA_PROTEIN_DOMAINS' value='${hg19BaseDirectory}/tools_data/arriba/protein_domains_hg19_hs37d5_GRCh37_v${ARRIBA_VERSION}.gff3' type='string'/>
+        <cvalue name='ARRIBA_CYTOBANDS' value='${hg19BaseDirectory}/tools_data/arriba/cytobands_hg19_hs37d5_GRCh37_v${ARRIBA_VERSION}.tsv' type="string"/>
 
         <!-- ## -->
         <!-- ## SOFTWARE PARAMS -->

--- a/resources/configurationFiles/analysisRNAseqGRCh38.xml
+++ b/resources/configurationFiles/analysisRNAseqGRCh38.xml
@@ -38,10 +38,11 @@
         <cvalue name='GENOME_STAR_INDEX_100' value='${hg38IndexDirectory}/STAR/STAR_2.7.6a_Gencode31/STAR_2.7.6a_GRCh38_decoy_ebv_phiX_alt_hla_chr_Gencode31_100bp' type='string'/>
         <cvalue name='GENOME_STAR_INDEX_200' value='${hg38IndexDirectory}/STAR/STAR_2.7.6a_Gencode31/STAR_2.7.6a_GRCh38_decoy_ebv_phiX_alt_hla_chr_Gencode31_200bp' type='string'/>
         <cvalue name='GENOME_KALLISTO_INDEX' value='${hg38IndexDirectory}/kallisto/kallisto-0.46.0_GRCh38_decoy_ebv_phiX_alt_hla_chr_Gencode31_k31/kallisto-0.46.0_GRCh38_decoy_ebv_phiX_alt_hla_chr_Gencode31.noGenes.index' type='string'/>
-        <cvalue name='ARRIBA_KNOWN_FUSIONS' value='${hg38BaseDirectory}/tools_data/arriba/known_fusions_CancerGeneCensus_gencode31_2017-05-11.tsv.gz' type='string'/>
-        <cvalue name='ARRIBA_BLACKLIST' value='${hg38BaseDirectory}/tools_data/arriba/blacklist_hg38_GRCh38_2018-11-04.tsv.gz' type='string'/>
-        <cvalue name='ARRIBA_PROTEIN_DOMAINS' value='${hg38BaseDirectory}/tools_data/arriba/protein_domains_hg38_GRCh38_2019-07-05.gff3' type='string'/>
-        <cvalue name='ARRIBA_CYTOBANDS' value='${hg38BaseDirectory}/tools_data/arriba/cytobands_hg38_GRCh38_2018-02-23.tsv' type="string"/>
+        <cvalue name='ARRIBA_KNOWN_FUSIONS' value='${hg38BaseDirectory}/tools_data/arriba/known_fusions_hg38_GRCh38_v${ARRIBA_VERSION}.tsv.gz' type='string'/>
+        <cvalue name='ARRIBA_TAGS' value='${ARRIBA_KNOWN_FUSIONS}' type='string'/>
+        <cvalue name='ARRIBA_BLACKLIST' value='${hg38BaseDirectory}/tools_data/arriba/blacklist_hg38_GRCh38_v${ARRIBA_VERSION}.tsv.gz' type='string'/>
+        <cvalue name='ARRIBA_PROTEIN_DOMAINS' value='${hg38BaseDirectory}/tools_data/arriba/protein_domains_hg38_GRCh38_v${ARRIBA_VERSION}.gff3' type='string'/>
+        <cvalue name='ARRIBA_CYTOBANDS' value='${hg38BaseDirectory}/tools_data/arriba/cytobands_hg38_GRCh38_v${ARRIBA_VERSION}.tsv' type="string"/>
 
         <!-- Hg38 Finger printing-->
         <cvalue name="fingerprintingSitesFile_hs38" value="${hg38DatabaseDirectory}/fingerprinting/hovestadt_v1.1/snp138Common.n1000_hg38.vh20140318.bed" type="path"/>


### PR DESCRIPTION
Adaptations for Arriba 2.2.1.

TODOs:

- To which version number should I update the workflow? Should I update the version number at all? Or will it be merged into a different branch which already has a new version number?
- There is a conda environment in `environment.yaml` listing all required packages for Arriba Version 1.2.0. But it is not used by the workflow as far as I can tell. How should I proceed with it? Should I update the environment to Arriba Version 2.2.1? If so, how was the environment created? It contains a lot of packages which are just the dependencies of the primary packages needed to run the workflow.